### PR TITLE
Reorganized OpenPage(...) in Utils.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,8 @@
 				</aside>
 				</div>
 			</div>
-		<div class="flexbox-container" id="Contact" style="margin-left: 1em; visibility: hidden;">
+		<div class="flexbox-container" id="Contact" style="margin-left: 1em;">
+			<p>hello</p>
 		</div>
 			</div>
 		<footer>

--- a/scripts/Utils.js
+++ b/scripts/Utils.js
@@ -13,14 +13,18 @@ export function GenerateLinkButton(p_Text, p_Url){
 
 export function OpenPage(elmnt, color) {
 	var i, tabcontent, tablinks;
+
 	tabcontent = document.getElementsByClassName("flexbox-container");
-	for (i = 0; i < tabcontent.length; i++)
-		tabcontent[i].style.visibility = "hidden";
-
 	tablinks = document.getElementsByClassName("Navbar-link");
-	for (i = 0; i < tablinks.length; i++)
-		tablinks[i].style.backgroundColor = "#555";
 
-	document.getElementById(elmnt.innerHTML).style.visibility = "visible";
+	for (i = 0; i < tabcontent.length; i++)
+		tabcontent[i].style.display = "none"; // collapse all the pages content.
+
+	for (i = 0; i < tablinks.length; i++)
+		tablinks[i].style.backgroundColor = "#555"; // reset all the navbar buttons colors.
+
+	// Set the display information for the active page.
+	let activePage = document.getElementById(elmnt.innerHTML);
+	activePage.style.display = "flex";
 	elmnt.style.backgroundColor = color;
 }

--- a/site-behavior.js
+++ b/site-behavior.js
@@ -71,7 +71,11 @@ function GenerateHeaderButtons(){
 			default:
 				break;
 		}
-		if(btn.innerHTML == "Home") btn.style.backgroundColor = "black";
+		if(btn.innerHTML == "Home"){
+			btn.style.backgroundColor = "black";
+			activePage = btn.innerHTML;
+			btn.click();
+		}
 	})
 }
 


### PR DESCRIPTION
set display to none actually collapsing the content instead of just making it invisible.